### PR TITLE
Dove: handle {{sender}} correctly in Move source files

### DIFF
--- a/dove/src/index/meta.rs
+++ b/dove/src/index/meta.rs
@@ -21,8 +21,15 @@ pub fn source_meta(
 ) -> Result<FileMeta, Error> {
     let name = ConstPool::push(file.to_str().unwrap_or("source"));
     let source = fs::read_to_string(file)?;
+    let sender = dialect.normalize_account_address(&address.unwrap().short_str_lossless())?;
 
-    let (defs, _, errors, _) = parse_file(dialect, &mut HashMap::default(), name, &source, None);
+    let (defs, _, errors, _) = parse_file(
+        dialect,
+        &mut HashMap::default(),
+        name,
+        &source,
+        Some(&sender),
+    );
     if errors.is_empty() {
         let mut metadata = Vec::new();
         for def in defs {

--- a/lang/src/compiler/dialects/libra/mod.rs
+++ b/lang/src/compiler/dialects/libra/mod.rs
@@ -18,7 +18,11 @@ impl Dialect for LibraDialect {
     }
 
     fn normalize_account_address(&self, addr: &str) -> Result<ProvidedAccountAddress> {
-        let address = LibraAccountAddress::from_hex_literal(&addr)?;
+        let address = if addr.starts_with("0x") {
+            LibraAccountAddress::from_hex_literal(addr)?
+        } else {
+            LibraAccountAddress::from_hex_literal(&format!("0x{}", addr))?
+        };
         let normalized_address = format!("0x{}", address);
         let lowered = format!("0x00000000{}", address);
         Ok(ProvidedAccountAddress::new(


### PR DESCRIPTION
Hello everyone, and many thanks for Dove :slightly_smiling_face: 
This PR contains two commits:

**dove: replace {{sender}} in Move source files**
    
Now Dove handles {{sender}} correctly in Move source files: replacing
every occurrence with the sender's address set in Dove.toml.

**lang: improved address normalization with Libra (Diem) addresses**

Address normalization used to expect only "0x.." addresses.
However, some methods such as move-core's
AccountAddess::short_str_lossless() return an address without "0x".

And since some move-tools functions seem to use "0x", we can't
presume that the address would not have "0x".

Hence the method is changed to work with addresses with, or without
"0x".