### PR TITLE
Fixset

### DIFF
--- a/dove/src/cmd/build.rs
+++ b/dove/src/cmd/build.rs
@@ -56,8 +56,8 @@ pub struct Build {
 impl Cmd for Build {
     fn apply(self, ctx: Context) -> Result<(), Error> {
         let dirs = ctx.paths_for(&[
-            &ctx.manifest.layout.script_dir,
-            &ctx.manifest.layout.module_dir,
+            &ctx.manifest.layout.scripts_dir,
+            &ctx.manifest.layout.modules_dir,
         ]);
 
         let mut index = ctx.build_index()?;
@@ -140,7 +140,7 @@ impl Build {
     fn store_modules(&self, ctx: &Context, units: Vec<CompiledUnit>) -> Result<(), Error> {
         if !units.is_empty() {
             if self.package {
-                let packages_dir = ctx.path_for(&ctx.manifest.layout.bundle_output);
+                let packages_dir = ctx.path_for(&ctx.manifest.layout.bundles_output);
                 if !packages_dir.exists() {
                     fs::create_dir_all(&packages_dir)?;
                 }
@@ -171,7 +171,7 @@ impl Build {
                 let package = ModulePackage::with_units(units);
                 File::create(&pac_file)?.write_all(&package.encode()?)?
             } else {
-                let modules_dir = ctx.path_for(&ctx.manifest.layout.module_output);
+                let modules_dir = ctx.path_for(&ctx.manifest.layout.modules_output);
                 if modules_dir.exists() {
                     fs::remove_dir_all(&modules_dir)?;
                 }
@@ -185,7 +185,7 @@ impl Build {
 
     fn store_scripts(&self, ctx: &Context, units: Vec<CompiledUnit>) -> Result<(), Error> {
         if !units.is_empty() {
-            let scripts_dir = ctx.path_for(&ctx.manifest.layout.script_output);
+            let scripts_dir = ctx.path_for(&ctx.manifest.layout.scripts_output);
             if scripts_dir.exists() {
                 fs::remove_dir_all(&scripts_dir)?;
             }

--- a/dove/src/cmd/build.rs
+++ b/dove/src/cmd/build.rs
@@ -140,7 +140,7 @@ impl Build {
     fn store_modules(&self, ctx: &Context, units: Vec<CompiledUnit>) -> Result<(), Error> {
         if !units.is_empty() {
             if self.package {
-                let packages_dir = ctx.path_for(&ctx.manifest.layout.packages_output);
+                let packages_dir = ctx.path_for(&ctx.manifest.layout.bundle_output);
                 if !packages_dir.exists() {
                     fs::create_dir_all(&packages_dir)?;
                 }

--- a/dove/src/cmd/clean.rs
+++ b/dove/src/cmd/clean.rs
@@ -10,15 +10,15 @@ pub struct Clean {}
 
 impl Cmd for Clean {
     fn apply(self, ctx: Context) -> Result<(), Error> {
-        let target = ctx.path_for(&ctx.manifest.layout.target);
+        let artifacts = ctx.path_for(&ctx.manifest.layout.artifacts);
         let index_path = ctx.path_for(&ctx.manifest.layout.index);
 
         if index_path.exists() {
             fs::remove_file(index_path)?;
         }
 
-        if target.exists() {
-            fs::remove_dir_all(target).map_err(Into::into)
+        if artifacts.exists() {
+            fs::remove_dir_all(artifacts).map_err(Into::into)
         } else {
             Ok(())
         }

--- a/dove/src/cmd/init.rs
+++ b/dove/src/cmd/init.rs
@@ -89,8 +89,8 @@ impl Cmd for Init {
             .ok_or_else(|| anyhow!("Failed to extract directory name."))?;
 
         if !self.minimal {
-            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.module_dir))?;
-            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.script_dir))?;
+            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.modules_dir))?;
+            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.scripts_dir))?;
             fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.tests_dir))?;
         }
 

--- a/dove/src/cmd/init.rs
+++ b/dove/src/cmd/init.rs
@@ -14,6 +14,9 @@ use crate::cmd::Cmd;
 use crate::context::{Context, get_context};
 use crate::manifest::{DoveToml, MANIFEST};
 
+const PONT_STDLIB: &str =
+    r#"{ git = "https://github.com/pontem-network/move-stdlib", tag = "v0.1.2" }"#;
+
 /// Init project command.
 #[derive(StructOpt, Debug)]
 pub struct Init {
@@ -39,15 +42,29 @@ pub struct Init {
         short = "d"
     )]
     dialect: String,
+
+    #[structopt(
+        help = "Creates only Dove.toml.",
+        name = "minimal",
+        long = "minimal",
+        short = "m"
+    )]
+    minimal: bool,
 }
 
 impl Init {
     /// Creates a new Init command.
-    pub fn new(repository: Option<Uri>, address: Option<String>, dialect: String) -> Init {
+    pub fn new(
+        repository: Option<Uri>,
+        address: Option<String>,
+        dialect: String,
+        minimal: bool,
+    ) -> Init {
         Init {
             repository,
             address,
             dialect,
+            minimal,
         }
     }
 }
@@ -70,9 +87,12 @@ impl Cmd for Init {
             .file_name()
             .and_then(|name| name.to_str())
             .ok_or_else(|| anyhow!("Failed to extract directory name."))?;
-        fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.module_dir))?;
-        fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.script_dir))?;
-        fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.tests_dir))?;
+
+        if !self.minimal {
+            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.module_dir))?;
+            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.script_dir))?;
+            fs::create_dir_all(ctx.path_for(&ctx.manifest.layout.tests_dir))?;
+        }
 
         let mut f = OpenOptions::new()
             .create(true)
@@ -94,14 +114,15 @@ impl Cmd for Init {
 
         writeln!(&mut f, "dialect = \"{}\"", self.dialect)?;
 
-        if dialect.name() == DialectName::Pont {
+        if !self.minimal && dialect.name() == DialectName::Pont {
             write!(
                 &mut f,
                 r#"
 dependencies = [
-    {{ git = "https://github.com/pontem-network/move-stdlib", tag = "v0.1.2" }}
+    {}
 ]
-"#
+"#,
+                PONT_STDLIB
             )?;
         }
         Ok(())

--- a/dove/src/cmd/metadata.rs
+++ b/dove/src/cmd/metadata.rs
@@ -29,7 +29,6 @@ fn into_metadata(mut ctx: Context) -> Result<DoveMetadata, Error> {
     let package_metadata = PackageMetadata {
         name: ctx.project_name(),
         account_address: ctx.manifest.package.account_address,
-        authors: ctx.manifest.package.authors,
         blockchain_api: ctx.manifest.package.blockchain_api,
         git_dependencies: git_deps,
         local_dependencies: local_deps,
@@ -74,9 +73,6 @@ pub struct PackageMetadata {
     /// Project AccountAddress.
     #[serde(default = "code_code_address")]
     pub account_address: String,
-    /// Authors list.
-    #[serde(default)]
-    pub authors: Vec<String>,
     /// dnode base url.
     pub blockchain_api: Option<String>,
     /// Git dependency list.

--- a/dove/src/cmd/metadata.rs
+++ b/dove/src/cmd/metadata.rs
@@ -156,13 +156,13 @@ mod tests {
         check_absolute(&metadata.package.local_dependencies[0]);
         check_absolute(&metadata.package.local_dependencies[1]);
 
-        check_absolute(&metadata.layout.module_dir);
-        check_absolute(&metadata.layout.script_dir);
+        check_absolute(&metadata.layout.modules_dir);
+        check_absolute(&metadata.layout.scripts_dir);
         check_absolute(&metadata.layout.tests_dir);
-        check_absolute(&metadata.layout.module_output);
-        check_absolute(&metadata.layout.bundle_output);
-        check_absolute(&metadata.layout.script_output);
-        check_absolute(&metadata.layout.transaction_output);
+        check_absolute(&metadata.layout.modules_output);
+        check_absolute(&metadata.layout.bundles_output);
+        check_absolute(&metadata.layout.scripts_output);
+        check_absolute(&metadata.layout.transactions_output);
         check_absolute(&metadata.layout.deps);
         check_absolute(&metadata.layout.artifacts);
         check_absolute(&metadata.layout.index);

--- a/dove/src/cmd/metadata.rs
+++ b/dove/src/cmd/metadata.rs
@@ -103,7 +103,7 @@ pub struct GitMetadata {
 impl GitMetadata {
     /// Create a new git metadata.
     pub fn new(git: Git, ctx: &Context) -> Result<GitMetadata, Error> {
-        let path: &Path = ctx.manifest.layout.target_deps.as_ref();
+        let path: &Path = ctx.manifest.layout.deps.as_ref();
         let path = ctx.path_for(path.join(&git::make_local_name(&git)));
         let local_path = if path.exists() {
             Some(str_path(path)?)
@@ -163,8 +163,8 @@ mod tests {
         check_absolute(&metadata.layout.packages_output);
         check_absolute(&metadata.layout.script_output);
         check_absolute(&metadata.layout.transaction_output);
-        check_absolute(&metadata.layout.target_deps);
-        check_absolute(&metadata.layout.target);
+        check_absolute(&metadata.layout.deps);
+        check_absolute(&metadata.layout.artifacts);
         check_absolute(&metadata.layout.index);
     }
 }

--- a/dove/src/cmd/metadata.rs
+++ b/dove/src/cmd/metadata.rs
@@ -160,7 +160,7 @@ mod tests {
         check_absolute(&metadata.layout.script_dir);
         check_absolute(&metadata.layout.tests_dir);
         check_absolute(&metadata.layout.module_output);
-        check_absolute(&metadata.layout.packages_output);
+        check_absolute(&metadata.layout.bundle_output);
         check_absolute(&metadata.layout.script_output);
         check_absolute(&metadata.layout.transaction_output);
         check_absolute(&metadata.layout.deps);

--- a/dove/src/cmd/new.rs
+++ b/dove/src/cmd/new.rs
@@ -36,6 +36,13 @@ pub struct New {
         short = "d"
     )]
     dialect: String,
+    #[structopt(
+        help = "Creates only Dove.toml without dependencies.",
+        name = "minimal",
+        long = "minimal",
+        short = "m"
+    )]
+    minimal: bool,
 }
 
 impl Cmd for New {
@@ -55,7 +62,7 @@ impl Cmd for New {
         fs::create_dir(&project_dir)?;
 
         ctx.project_dir = project_dir.clone();
-        let init = Init::new(self.repository, self.address, self.dialect);
+        let init = Init::new(self.repository, self.address, self.dialect, self.minimal);
         if let Err(err) = init.apply(ctx) {
             fs::remove_dir_all(&project_dir)?;
             Err(err)

--- a/dove/src/cmd/run.rs
+++ b/dove/src/cmd/run.rs
@@ -25,12 +25,12 @@ pub struct Run {
 
 impl Cmd for Run {
     fn apply(self, ctx: Context) -> Result<(), Error> {
-        let script_dir = ctx.path_for(&ctx.manifest.layout.script_dir);
+        let script_dir = ctx.path_for(&ctx.manifest.layout.scripts_dir);
         let script = script_dir.join(self.script).with_extension("move");
         if !script.exists() {
             return Err(anyhow!("Cannot open {:?}", script));
         }
-        let module_dir = ctx.path_for(&ctx.manifest.layout.module_dir);
+        let module_dir = ctx.path_for(&ctx.manifest.layout.modules_dir);
 
         let mut index = ctx.build_index()?;
 

--- a/dove/src/cmd/run.rs
+++ b/dove/src/cmd/run.rs
@@ -38,19 +38,17 @@ impl Cmd for Run {
         let mut dep_list = load_dependencies(dep_set)?;
         dep_list.extend(load_move_files(&[module_dir])?);
 
-        let signers = self
+        let mut signers = self
             .signers
             .iter()
             .map(|signer| ctx.dialect.parse_address(signer))
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let sender = self
-            .signers
-            .get(0)
-            .map(|addr| ctx.dialect.parse_address(addr))
-            .unwrap_or_else(|| ctx.account_address())?;
+        if signers.is_empty() {
+            signers.push(ctx.account_address()?);
+        }
 
-        let executor = Executor::new(ctx.dialect.as_ref(), sender, dep_list);
+        let executor = Executor::new(ctx.dialect.as_ref(), signers[0], dep_list);
         let script = MoveFile::load(script)?;
 
         render_execution_result(executor.execute_script(script, Some(signers), self.args))

--- a/dove/src/cmd/test.rs
+++ b/dove/src/cmd/test.rs
@@ -24,8 +24,8 @@ impl Cmd for Test {
         }
 
         let mut dirs = ctx.paths_for(&[
-            &ctx.manifest.layout.script_dir,
-            &ctx.manifest.layout.module_dir,
+            &ctx.manifest.layout.scripts_dir,
+            &ctx.manifest.layout.modules_dir,
         ]);
 
         dirs.push(tests_dir.clone());

--- a/dove/src/cmd/tx.rs
+++ b/dove/src/cmd/tx.rs
@@ -208,7 +208,7 @@ impl<'a> TransactionBuilder<'a> {
     fn lookup_script_by_file_name(&self, fname: &str) -> Result<(MoveFile, Meta), Error> {
         let script_path = self
             .dove_ctx
-            .path_for(&self.dove_ctx.manifest.layout.script_dir);
+            .path_for(&self.dove_ctx.manifest.layout.scripts_dir);
         let file_path = if !fname.ends_with("move") {
             let mut path = script_path.join(fname);
             path.set_extension("move");
@@ -258,7 +258,7 @@ impl<'a> TransactionBuilder<'a> {
     fn lookup_script_by_name(&self, name: &str) -> Result<(MoveFile, Meta), Error> {
         let script_path = self
             .dove_ctx
-            .path_for(&self.dove_ctx.manifest.layout.script_dir);
+            .path_for(&self.dove_ctx.manifest.layout.scripts_dir);
         let sender = self.dove_ctx.account_address()?;
         let mut files = find_move_files(&script_path)?
             .iter()
@@ -333,7 +333,7 @@ impl<'a> TransactionBuilder<'a> {
 
         let script_path = self
             .dove_ctx
-            .path_for(&self.dove_ctx.manifest.layout.script_dir);
+            .path_for(&self.dove_ctx.manifest.layout.scripts_dir);
         let files = find_move_files(&script_path)?;
         if files.len() == 1 {
             let mf = MoveFile::load(&files[0])?;
@@ -357,7 +357,7 @@ impl<'a> TransactionBuilder<'a> {
 
         let module_dir = self
             .dove_ctx
-            .path_for(&self.dove_ctx.manifest.layout.module_dir)
+            .path_for(&self.dove_ctx.manifest.layout.modules_dir)
             .to_str()
             .map(|path| path.to_owned())
             .ok_or_else(|| anyhow!("Failed to convert module dir path"))?;
@@ -672,7 +672,7 @@ where
 }
 
 fn store_transaction(ctx: &Context, name: &str, tx: Transaction) -> Result<(), Error> {
-    let tx_dir = ctx.path_for(&ctx.manifest.layout.transaction_output);
+    let tx_dir = ctx.path_for(&ctx.manifest.layout.transactions_output);
     if !tx_dir.exists() {
         fs::create_dir_all(&tx_dir)?;
     }

--- a/dove/src/index/mod.rs
+++ b/dove/src/index/mod.rs
@@ -38,7 +38,7 @@ pub struct Index<'a> {
 impl<'a> Index<'a> {
     /// Build modules index.
     pub fn build(&mut self) -> Result<(), Error> {
-        let deps_path = self.ctx.path_for(&self.ctx.manifest.layout.target_deps);
+        let deps_path = self.ctx.path_for(&self.ctx.manifest.layout.deps);
         if !deps_path.exists() {
             fs::create_dir_all(&deps_path)?;
         }

--- a/dove/src/index/resolver/chain/mod.rs
+++ b/dove/src/index/resolver/chain/mod.rs
@@ -85,7 +85,7 @@ impl<'a> ChainIndex<'a> {
 }
 
 fn make_path(ctx: &Context, module_id: &ModuleId) -> PathBuf {
-    let deps_dir = ctx.path_for(&ctx.manifest.layout.target_deps);
+    let deps_dir = ctx.path_for(&ctx.manifest.layout.deps);
     deps_dir.join(make_local_name(module_id))
 }
 

--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -25,7 +25,7 @@ pub const PREFIX: &str = "git";
 pub fn resolve(ctx: &Context, git: &Git) -> Result<PathBuf, Error> {
     let checkout_params = CheckoutParams::try_from(git)?;
 
-    let deps = ctx.path_for(&ctx.manifest.layout.target_deps);
+    let deps = ctx.path_for(&ctx.manifest.layout.deps);
     let local_name = make_local_name(&git);
     let mut repo_path = deps.join(&local_name);
 

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -73,31 +73,31 @@ fn tests_dir() -> String {
 }
 
 fn module_output() -> String {
-    "target/modules".to_owned()
+    "artifacts/modules".to_owned()
 }
 
 fn script_output() -> String {
-    "target/scripts".to_owned()
+    "artifacts/scripts".to_owned()
 }
 
 fn transaction_output() -> String {
-    "target/transactions".to_owned()
+    "artifacts/transactions".to_owned()
 }
 
 fn packages_output() -> String {
-    "target/packages".to_owned()
+    "artifacts/packages".to_owned()
 }
 
-fn target_deps() -> String {
-    "target/.external".to_owned()
+fn deps() -> String {
+    "artifacts/.external".to_owned()
 }
 
-fn target() -> String {
-    "target".to_owned()
+fn artifacts() -> String {
+    "artifacts".to_owned()
 }
 
 fn index() -> String {
-    "target/.Dove.man".to_owned()
+    "artifacts/.Dove.man".to_owned()
 }
 
 fn code_code_address() -> String {
@@ -136,12 +136,12 @@ pub struct Layout {
     pub transaction_output: String,
 
     /// Directory with external dependencies.
-    #[serde(default = "target_deps")]
-    pub target_deps: String,
+    #[serde(default = "deps")]
+    pub deps: String,
 
-    /// Target directory.
-    #[serde(default = "target")]
-    pub target: String,
+    /// Artifacts directory.
+    #[serde(default = "artifacts")]
+    pub artifacts: String,
 
     /// Path to index.
     #[serde(default = "index")]
@@ -159,8 +159,8 @@ impl Layout {
             packages_output: ctx.str_path_for(&self.packages_output)?,
             script_output: ctx.str_path_for(&self.script_output)?,
             transaction_output: ctx.str_path_for(&self.transaction_output)?,
-            target_deps: ctx.str_path_for(&self.target_deps)?,
-            target: ctx.str_path_for(&self.target)?,
+            deps: ctx.str_path_for(&self.deps)?,
+            artifacts: ctx.str_path_for(&self.artifacts)?,
             index: ctx.str_path_for(&self.index)?,
         })
     }
@@ -176,8 +176,8 @@ impl Default for Layout {
             packages_output: packages_output(),
             script_output: script_output(),
             transaction_output: transaction_output(),
-            target_deps: target_deps(),
-            target: target(),
+            deps: deps(),
+            artifacts: artifacts(),
             index: index(),
         }
     }

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -16,7 +16,7 @@ use crate::context::Context;
 /// Dove manifest name.
 pub const MANIFEST: &str = "Dove.toml";
 
-/// Movec manifest.
+/// Dove manifest.
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct DoveToml {
     /// Project info.
@@ -34,9 +34,6 @@ pub struct Package {
     /// Project account address.
     #[serde(default = "code_code_address")]
     pub account_address: String,
-    /// Authors list.
-    #[serde(default)]
-    pub authors: Vec<String>,
     /// dnode base url.
     pub blockchain_api: Option<String>,
     /// Dependency list.
@@ -51,7 +48,6 @@ impl Default for Package {
         Package {
             name: None,
             account_address: code_code_address(),
-            authors: Default::default(),
             blockchain_api: None,
             dependencies: None,
             dialect: None,
@@ -374,7 +370,6 @@ mod test {
         Package {
             name: Some("Foo".to_owned()),
             account_address: "0x01".to_owned(),
-            authors: vec![],
             blockchain_api: None,
             dependencies: Some(Dependencies {
                 deps: vec![

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -60,11 +60,11 @@ fn dialect() -> Option<String> {
     Some(default_dialect())
 }
 
-fn module_dir() -> String {
+fn modules_dir() -> String {
     "modules".to_owned()
 }
 
-fn script_dir() -> String {
+fn scripts_dir() -> String {
     "scripts".to_owned()
 }
 
@@ -72,19 +72,19 @@ fn tests_dir() -> String {
     "tests".to_owned()
 }
 
-fn module_output() -> String {
+fn modules_output() -> String {
     "artifacts/modules".to_owned()
 }
 
-fn script_output() -> String {
+fn scripts_output() -> String {
     "artifacts/scripts".to_owned()
 }
 
-fn transaction_output() -> String {
+fn transactions_output() -> String {
     "artifacts/transactions".to_owned()
 }
 
-fn bundle_output() -> String {
+fn bundles_output() -> String {
     "artifacts/bundles".to_owned()
 }
 
@@ -108,32 +108,32 @@ fn code_code_address() -> String {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Layout {
     /// Directory with module sources.
-    #[serde(default = "module_dir")]
-    pub module_dir: String,
+    #[serde(default = "modules_dir")]
+    pub modules_dir: String,
 
     /// Directory with script sources.
-    #[serde(default = "script_dir")]
-    pub script_dir: String,
+    #[serde(default = "scripts_dir")]
+    pub scripts_dir: String,
 
     /// Directory with tests.
     #[serde(default = "tests_dir")]
     pub tests_dir: String,
 
     /// Directory with compiled modules.
-    #[serde(default = "module_output")]
-    pub module_output: String,
+    #[serde(default = "modules_output")]
+    pub modules_output: String,
 
     /// Directory with module package.
-    #[serde(default = "bundle_output")]
-    pub bundle_output: String,
+    #[serde(default = "bundles_output")]
+    pub bundles_output: String,
 
     /// Directory with compiled scripts.
-    #[serde(default = "script_output")]
-    pub script_output: String,
+    #[serde(default = "scripts_output")]
+    pub scripts_output: String,
 
     /// Directory with transactions.
-    #[serde(default = "transaction_output")]
-    pub transaction_output: String,
+    #[serde(default = "transactions_output")]
+    pub transactions_output: String,
 
     /// Directory with external dependencies.
     #[serde(default = "deps")]
@@ -152,13 +152,13 @@ impl Layout {
     /// Returns layout instance with absolute paths.
     pub fn to_absolute(&self, ctx: &Context) -> Result<Layout, Error> {
         Ok(Layout {
-            module_dir: ctx.str_path_for(&self.module_dir)?,
-            script_dir: ctx.str_path_for(&self.script_dir)?,
+            modules_dir: ctx.str_path_for(&self.modules_dir)?,
+            scripts_dir: ctx.str_path_for(&self.scripts_dir)?,
             tests_dir: ctx.str_path_for(&self.tests_dir)?,
-            module_output: ctx.str_path_for(&self.module_output)?,
-            bundle_output: ctx.str_path_for(&self.bundle_output)?,
-            script_output: ctx.str_path_for(&self.script_output)?,
-            transaction_output: ctx.str_path_for(&self.transaction_output)?,
+            modules_output: ctx.str_path_for(&self.modules_output)?,
+            bundles_output: ctx.str_path_for(&self.bundles_output)?,
+            scripts_output: ctx.str_path_for(&self.scripts_output)?,
+            transactions_output: ctx.str_path_for(&self.transactions_output)?,
             deps: ctx.str_path_for(&self.deps)?,
             artifacts: ctx.str_path_for(&self.artifacts)?,
             index: ctx.str_path_for(&self.index)?,
@@ -169,13 +169,13 @@ impl Layout {
 impl Default for Layout {
     fn default() -> Self {
         Layout {
-            module_dir: module_dir(),
-            script_dir: script_dir(),
+            modules_dir: modules_dir(),
+            scripts_dir: scripts_dir(),
             tests_dir: tests_dir(),
-            module_output: module_output(),
-            bundle_output: bundle_output(),
-            script_output: script_output(),
-            transaction_output: transaction_output(),
+            modules_output: modules_output(),
+            bundles_output: bundles_output(),
+            scripts_output: scripts_output(),
+            transactions_output: transactions_output(),
             deps: deps(),
             artifacts: artifacts(),
             index: index(),

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -84,8 +84,8 @@ fn transaction_output() -> String {
     "artifacts/transactions".to_owned()
 }
 
-fn packages_output() -> String {
-    "artifacts/packages".to_owned()
+fn bundle_output() -> String {
+    "artifacts/bundles".to_owned()
 }
 
 fn deps() -> String {
@@ -124,8 +124,8 @@ pub struct Layout {
     pub module_output: String,
 
     /// Directory with module package.
-    #[serde(default = "packages_output")]
-    pub packages_output: String,
+    #[serde(default = "bundle_output")]
+    pub bundle_output: String,
 
     /// Directory with compiled scripts.
     #[serde(default = "script_output")]
@@ -156,7 +156,7 @@ impl Layout {
             script_dir: ctx.str_path_for(&self.script_dir)?,
             tests_dir: ctx.str_path_for(&self.tests_dir)?,
             module_output: ctx.str_path_for(&self.module_output)?,
-            packages_output: ctx.str_path_for(&self.packages_output)?,
+            bundle_output: ctx.str_path_for(&self.bundle_output)?,
             script_output: ctx.str_path_for(&self.script_output)?,
             transaction_output: ctx.str_path_for(&self.transaction_output)?,
             deps: ctx.str_path_for(&self.deps)?,
@@ -173,7 +173,7 @@ impl Default for Layout {
             script_dir: script_dir(),
             tests_dir: tests_dir(),
             module_output: module_output(),
-            packages_output: packages_output(),
+            bundle_output: bundle_output(),
             script_output: script_output(),
             transaction_output: transaction_output(),
             deps: deps(),


### PR DESCRIPTION
Use project account address as default script signer.
Remove authors from the manifest.
Rename target to artifacts. Resolved naming collision with cargo.
Added minimal flag for new and init.