### PR TITLE
[PONC-69] Move prover integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --all
+          args: --no-fail-fast --all --all-features
 
   wasm:
     name: wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,6 @@ dependencies = [
  "boogie-backend-v2",
  "decompiler",
  "dunce",
- "env_logger 0.8.4",
  "fs_extra",
  "git-hash",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "approx"
@@ -209,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -390,9 +390,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
  "cc",
@@ -551,7 +551,7 @@ dependencies = [
  "diem-workspace-hack",
  "futures 0.3.15",
  "handlebars",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-core-types",
  "move-model",
@@ -562,7 +562,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "vm",
 ]
 
@@ -579,7 +579,7 @@ dependencies = [
  "diem-workspace-hack",
  "futures 0.3.15",
  "handlebars",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-core-types",
  "move-model",
@@ -590,7 +590,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "vm",
 ]
 
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-slice-cast"
@@ -653,7 +653,7 @@ dependencies = [
  "diem-types",
  "diem-workspace-hack",
  "ir-to-bytecode",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-core-types",
  "move-model",
@@ -734,9 +734,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 dependencies = [
  "jobserver",
 ]
@@ -820,7 +820,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -982,11 +982,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -1024,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1112,7 +1111,7 @@ dependencies = [
  "convert_case",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1151,7 +1150,7 @@ source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1185,7 +1184,7 @@ dependencies = [
  "diem-workspace-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1241,7 +1240,7 @@ dependencies = [
  "diem-crypto-derive",
  "enum-iterator",
  "hex",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "mirai-annotations",
  "move-core-types",
  "once_cell",
@@ -1274,9 +1273,9 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hyper 0.14.7",
+ "hyper 0.14.9",
  "indexmap",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "itoa",
  "libc",
  "log",
@@ -1298,8 +1297,8 @@ dependencies = [
  "standback",
  "subtle 2.4.0",
  "syn 0.15.44",
- "syn 1.0.72",
- "tokio 1.6.0",
+ "syn 1.0.73",
+ "tokio 1.6.2",
  "tokio-util 0.6.7",
  "toml",
  "tracing",
@@ -1341,7 +1340,7 @@ dependencies = [
  "codespan 0.8.0",
  "codespan-reporting 0.8.0",
  "diem-workspace-hack",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-model",
  "num",
@@ -1360,6 +1359,7 @@ dependencies = [
  "boogie-backend-v2",
  "decompiler",
  "dunce",
+ "env_logger 0.8.4",
  "fs_extra",
  "git-hash",
  "git2",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "dyn-clonable"
@@ -1415,7 +1415,7 @@ checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1495,7 +1495,7 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -1532,9 +1532,9 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
+checksum = "e5b36e6f2295f393f44894c6031f67df4d185b984cd54d08f768ce678007efcd"
 dependencies = [
  "serde",
 ]
@@ -1588,7 +1588,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]
 
@@ -1749,7 +1749,7 @@ dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1773,7 +1773,7 @@ checksum = "66fb72ae75d457bfcb457e1098cf18134967e9069ecc4bba2c77416924b44843"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1878,9 +1878,9 @@ checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1901,7 +1901,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2009,9 +2009,9 @@ version = "0.1.0"
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
 dependencies = [
  "bitflags",
  "libc",
@@ -2075,7 +2075,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2285,9 +2285,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -2342,11 +2342,11 @@ dependencies = [
  "http",
  "http-body 0.4.2",
  "httparse",
- "httpdate 1.0.0",
+ "httpdate 1.0.1",
  "itoa",
- "pin-project 1.0.7",
+ "pin-project-lite 0.2.6",
  "socket2 0.4.0",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tower-service",
  "tracing",
  "want",
@@ -2372,9 +2372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.0.1",
- "hyper 0.14.7",
+ "hyper 0.14.9",
  "native-tls",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tokio-native-tls",
 ]
 
@@ -2426,7 +2426,7 @@ checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2450,7 +2450,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "ir-to-bytecode"
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -2636,7 +2636,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2736,15 +2736,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.21+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
 dependencies = [
  "cc",
  "libc",
@@ -2822,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2946,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.89.0"
+version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07731ecd4ee0654728359a5b95e2a254c857876c04b85225496a35d60345daa7"
+checksum = "852e0dedfd52cc32325598b2631e0eba31b7b708959676a9f837042f276b09a2"
 dependencies = [
  "bitflags",
  "serde",
@@ -3001,9 +3001,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -3084,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -3262,7 +3262,7 @@ dependencies = [
  "codespan 0.8.0",
  "codespan-reporting 0.8.0",
  "diem-workspace-hack",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-core-types",
  "move-ir-types",
@@ -3296,7 +3296,7 @@ dependencies = [
  "futures 0.3.15",
  "handlebars",
  "hex",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "move-ir-types",
  "move-lang",
@@ -3309,7 +3309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "toml",
  "vm",
 ]
@@ -3320,7 +3320,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap 3.0.0-beta.2",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "git-hash",
  "hex",
  "http",
@@ -3656,7 +3656,7 @@ dependencies = [
  "diem-workspace-hack",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3671,15 +3671,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 dependencies = [
  "parking_lot 0.11.1",
 ]
@@ -3790,7 +3793,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3815,7 +3818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2 1.0.27",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]
 
@@ -3950,7 +3953,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4000,7 +4003,7 @@ checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4011,7 +4014,7 @@ checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4040,14 +4043,14 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "log",
- "wepoll-sys",
+ "wepoll-ffi",
  "winapi 0.3.9",
 ]
 
@@ -4119,7 +4122,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "version_check",
 ]
 
@@ -4240,7 +4243,7 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4253,7 +4256,7 @@ dependencies = [
  "itertools 0.9.0",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4368,7 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
@@ -4395,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
@@ -4572,7 +4575,7 @@ checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4589,11 +4592,10 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
@@ -4630,7 +4632,7 @@ checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4682,7 +4684,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.2",
- "hyper 0.14.7",
+ "hyper 0.14.9",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -4695,7 +4697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -4888,7 +4890,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde_derive_internals",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4942,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4955,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4974,9 +4976,9 @@ dependencies = [
 
 [[package]]
 name = "serde-name"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87442b7a30baedc6e8875cb7156cb0e2cf41cdd9f13c34de73090c463f028bd8"
+checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
  "serde",
  "thiserror",
@@ -4999,7 +5001,7 @@ checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5010,7 +5012,7 @@ checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5033,7 +5035,7 @@ checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5127,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -5137,9 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -5220,7 +5222,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5381,7 +5383,7 @@ checksum = "558a1a24f2feab950ce382923b62879f253207c6cbf7832eb1e47dba5f57fba8"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5515,7 +5517,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5712,7 +5714,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5733,7 +5735,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5815,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -5832,7 +5834,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "unicode-xid 0.2.2",
 ]
 
@@ -5879,22 +5881,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5986,15 +5988,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "aea337f72e96efe29acc234d803a5981cd9a2b6ed21655cd7fc21cfe021e8ec7"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.11",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
@@ -6012,7 +6014,7 @@ checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -6022,7 +6024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.6.0",
+ "tokio 1.6.2",
 ]
 
 [[package]]
@@ -6032,7 +6034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "webpki",
 ]
 
@@ -6044,7 +6046,7 @@ checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.2",
 ]
 
 [[package]]
@@ -6066,7 +6068,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 1.0.7",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tungstenite",
 ]
 
@@ -6096,7 +6098,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "tokio 1.6.2",
 ]
 
 [[package]]
@@ -6135,7 +6137,7 @@ checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -6202,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec051edf7f0fc9499a2cb0947652cab2148b9d7f61cee7605e312e9f970dacaf"
+checksum = "cd81fe0c8bc2b528a51c9d2c31dae4483367a26a723a3c9a4a8120311d7774e3"
 dependencies = [
  "hash-db",
  "hashbrown 0.9.1",
@@ -6317,9 +6319,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -6418,9 +6420,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"
@@ -6501,7 +6503,7 @@ dependencies = [
  "futures 0.3.15",
  "headers",
  "http",
- "hyper 0.14.7",
+ "hyper 0.14.9",
  "log",
  "mime",
  "mime_guess",
@@ -6512,7 +6514,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.6.0",
+ "tokio 1.6.2",
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
@@ -6556,7 +6558,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-shared",
 ]
 
@@ -6590,7 +6592,7 @@ checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6660,10 +6662,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys"
-version = "3.0.1"
+name = "wepoll-ffi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
 ]
@@ -6786,6 +6788,6 @@ checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "abigen"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "bytecode-verifier",
+ "diem-types",
+ "diem-workspace-hack",
+ "heck",
+ "log",
+ "move-core-types",
+ "move-model",
+ "serde",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +343,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "atomic"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +538,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "boogie-backend"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "boogie-backend-v2",
+ "bytecode",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
+ "diem-workspace-hack",
+ "futures 0.3.15",
+ "handlebars",
+ "itertools 0.10.0",
+ "log",
+ "move-core-types",
+ "move-model",
+ "num",
+ "once_cell",
+ "pretty",
+ "rand 0.8.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio 1.6.0",
+ "vm",
+]
+
+[[package]]
+name = "boogie-backend-v2"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytecode",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
+ "diem-workspace-hack",
+ "futures 0.3.15",
+ "handlebars",
+ "itertools 0.10.0",
+ "log",
+ "move-core-types",
+ "move-model",
+ "num",
+ "once_cell",
+ "pretty",
+ "rand 0.8.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio 1.6.0",
+ "vm",
+]
+
+[[package]]
 name = "borrow-graph"
 version = "0.0.1"
 source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
@@ -557,6 +642,28 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "bytecode"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "borrow-graph",
+ "bytecode-verifier",
+ "diem-types",
+ "diem-workspace-hack",
+ "ir-to-bytecode",
+ "itertools 0.10.0",
+ "log",
+ "move-core-types",
+ "move-model",
+ "num",
+ "once_cell",
+ "petgraph",
+ "serde",
+ "serde_json",
+ "vm",
+]
 
 [[package]]
 name = "bytecode-source-map"
@@ -1111,6 +1218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-temppath"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "diem-workspace-hack",
+ "hex",
+ "rand 0.8.3",
+]
+
+[[package]]
 name = "diem-types"
 version = "0.0.1"
 source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
@@ -1215,12 +1332,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "docgen"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "bytecode",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
+ "diem-workspace-hack",
+ "itertools 0.10.0",
+ "log",
+ "move-model",
+ "num",
+ "once_cell",
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "dove"
 version = "1.2.0"
 dependencies = [
  "anyhow",
  "bcs",
  "bech32",
+ "boogie-backend-v2",
  "decompiler",
  "dunce",
  "fs_extra",
@@ -1236,6 +1373,7 @@ dependencies = [
  "move-core-types",
  "move-executor",
  "move-lang",
+ "move-prover",
  "net",
  "once_cell",
  "rand 0.7.3",
@@ -1398,6 +1536,20 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "errmapgen"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "diem-workspace-hack",
+ "log",
+ "move-core-types",
+ "move-model",
  "serde",
 ]
 
@@ -1929,6 +2081,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error 2.0.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,7 +2150,7 @@ dependencies = [
  "headers-core",
  "http",
  "mime",
- "sha-1",
+ "sha-1 0.9.6",
  "time",
 ]
 
@@ -2129,7 +2295,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -3086,6 +3252,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-model"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "anyhow",
+ "bytecode-source-map",
+ "bytecode-verifier",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
+ "diem-workspace-hack",
+ "itertools 0.10.0",
+ "log",
+ "move-core-types",
+ "move-ir-types",
+ "move-lang",
+ "num",
+ "once_cell",
+ "regex",
+ "serde",
+ "vm",
+]
+
+[[package]]
+name = "move-prover"
+version = "0.1.0"
+source = "git+https://github.com/pontem-network/diem.git?branch=release-1.2.0-v1#8e60a94405e69d25ca9a4a5dae8c68b7b1b30abb"
+dependencies = [
+ "abigen",
+ "anyhow",
+ "async-trait",
+ "boogie-backend",
+ "boogie-backend-v2",
+ "bytecode",
+ "bytecode-source-map",
+ "clap 2.33.3",
+ "codespan 0.8.0",
+ "codespan-reporting 0.8.0",
+ "diem-temppath",
+ "diem-workspace-hack",
+ "docgen",
+ "errmapgen",
+ "futures 0.3.15",
+ "handlebars",
+ "hex",
+ "itertools 0.10.0",
+ "log",
+ "move-ir-types",
+ "move-lang",
+ "move-model",
+ "num",
+ "once_cell",
+ "pretty",
+ "rand 0.8.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "tokio 1.6.0",
+ "toml",
+ "vm",
+]
+
+[[package]]
 name = "move-resource-viewer"
 version = "1.2.0"
 dependencies = [
@@ -3173,7 +3402,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1",
+ "sha-1 0.9.6",
  "sha2 0.9.5",
  "sha3",
  "unsigned-varint 0.5.1",
@@ -3196,7 +3425,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "quick-error",
+ "quick-error 1.2.3",
  "rand 0.7.3",
  "safemem",
  "tempfile",
@@ -3693,6 +3922,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3795,6 +4067,16 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+]
 
 [[package]]
 name = "primitive-types"
@@ -3989,6 +4271,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -4506,7 +4794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -4762,6 +5050,18 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
@@ -4849,6 +5149,17 @@ name = "signature"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+
+[[package]]
+name = "simplelog"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc0ffd69814a9b251d43afcabf96dad1b29f5028378056257be9e3fecc9f720"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
+]
 
 [[package]]
 name = "slab"
@@ -5931,7 +6242,7 @@ dependencies = [
  "input_buffer",
  "log",
  "rand 0.8.3",
- "sha-1",
+ "sha-1 0.9.6",
  "url 2.2.2",
  "utf-8",
 ]
@@ -5952,15 +6263,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.4.6",
  "static_assertions",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/dove/Cargo.toml
+++ b/dove/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
+env_logger = "*"
 structopt = "0.3"
 http = "0.2"
 serde = "1.0.125"
@@ -44,5 +45,11 @@ net = { path = "../net" }
 vm = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-core-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-lang = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
-move-prover = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
-boogie-backend-v2 = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
+
+# move-prover deps
+move-prover = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1", optional = true }
+boogie-backend-v2 = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1", optional = true }
+
+[features]
+default = []
+prover = ['move-prover', 'boogie-backend-v2']

--- a/dove/Cargo.toml
+++ b/dove/Cargo.toml
@@ -9,7 +9,6 @@ authors = [
 edition = "2018"
 
 [dependencies]
-env_logger = "*"
 structopt = "0.3"
 http = "0.2"
 serde = "1.0.125"

--- a/dove/Cargo.toml
+++ b/dove/Cargo.toml
@@ -44,3 +44,5 @@ net = { path = "../net" }
 vm = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-core-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-lang = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
+move-prover = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
+boogie-backend-v2 = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }

--- a/dove/src/cli.rs
+++ b/dove/src/cli.rs
@@ -9,7 +9,7 @@ use lang::compiler::ConstPool;
 
 use crate::cmd::build::Build;
 use crate::cmd::clean::Clean;
-use crate::cmd::prover::Prover;
+use crate::cmd::prover::Prove;
 use crate::cmd::tx::CreateTransactionCmd;
 use crate::cmd::fetch::Fetch;
 use crate::cmd::init::Init;

--- a/dove/src/cli.rs
+++ b/dove/src/cli.rs
@@ -9,6 +9,7 @@ use lang::compiler::ConstPool;
 
 use crate::cmd::build::Build;
 use crate::cmd::clean::Clean;
+use crate::cmd::prover::Prover;
 use crate::cmd::tx::CreateTransactionCmd;
 use crate::cmd::fetch::Fetch;
 use crate::cmd::init::Init;
@@ -68,6 +69,11 @@ enum Opt {
         #[structopt(flatten)]
         cmd: CreateTransactionCmd,
     },
+    #[structopt(about = "Run move prover")]
+    Prove {
+        #[structopt(flatten)]
+        cmd: Prove,
+    },
 }
 
 /// Public interface for the CLI (useful for testing).
@@ -89,5 +95,6 @@ where
         Opt::Test { cmd } => cmd.execute(cwd),
         Opt::Run { cmd } => cmd.execute(cwd),
         Opt::Tx { cmd } => cmd.execute(cwd),
+        Opt::Prove { cmd } => cmd.execute(cwd),
     }
 }

--- a/dove/src/cli.rs
+++ b/dove/src/cli.rs
@@ -9,7 +9,6 @@ use lang::compiler::ConstPool;
 
 use crate::cmd::build::Build;
 use crate::cmd::clean::Clean;
-use crate::cmd::prover::Prove;
 use crate::cmd::tx::CreateTransactionCmd;
 use crate::cmd::fetch::Fetch;
 use crate::cmd::init::Init;
@@ -69,10 +68,11 @@ enum Opt {
         #[structopt(flatten)]
         cmd: CreateTransactionCmd,
     },
+    #[cfg(feature = "prover")]
     #[structopt(about = "Run move prover")]
     Prove {
         #[structopt(flatten)]
-        cmd: Prove,
+        cmd: crate::cmd::prover::Prove,
     },
 }
 
@@ -95,6 +95,7 @@ where
         Opt::Test { cmd } => cmd.execute(cwd),
         Opt::Run { cmd } => cmd.execute(cwd),
         Opt::Tx { cmd } => cmd.execute(cwd),
+        #[cfg(feature = "prover")]
         Opt::Prove { cmd } => cmd.execute(cwd),
     }
 }

--- a/dove/src/cmd/mod.rs
+++ b/dove/src/cmd/mod.rs
@@ -20,14 +20,14 @@ pub mod init;
 pub mod metadata;
 /// Project creator.
 pub mod new;
+/// Run move prover.
+pub mod prover;
 /// Script executor.
 pub mod run;
 /// Test runner.
 pub mod test;
 /// Create transaction.
 pub mod tx;
-/// Run move prover.
-pub mod prover;
 
 /// Move command.
 pub trait Cmd {

--- a/dove/src/cmd/mod.rs
+++ b/dove/src/cmd/mod.rs
@@ -26,6 +26,8 @@ pub mod run;
 pub mod test;
 /// Create transaction.
 pub mod tx;
+/// Run move prover.
+pub mod prover;
 
 /// Move command.
 pub trait Cmd {

--- a/dove/src/cmd/mod.rs
+++ b/dove/src/cmd/mod.rs
@@ -20,14 +20,16 @@ pub mod init;
 pub mod metadata;
 /// Project creator.
 pub mod new;
-/// Run move prover.
-pub mod prover;
 /// Script executor.
 pub mod run;
 /// Test runner.
 pub mod test;
 /// Create transaction.
 pub mod tx;
+
+#[cfg(feature = "prover")]
+/// Run move prover.
+pub mod prover;
 
 /// Move command.
 pub trait Cmd {

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -57,14 +57,14 @@ impl Cmd for Prove {
             .map(|s| s.to_string())
             .collect();
 
-        let artifacts_dir = ctx
-            .path_for(&ctx.manifest.layout.artifacts)
-            .join("move-prover");
-        if artifacts_dir.exists() {
-            std::fs::remove_dir_all(&artifacts_dir)?;
+        let output_dir = ctx.path_for(&ctx.manifest.layout.move_prover_output);
+        if output_dir.exists() {
+            std::fs::remove_dir_all(&output_dir)?;
         }
-        std::fs::create_dir_all(artifacts_dir.join("modules"))?;
-        std::fs::create_dir_all(artifacts_dir.join("scripts"))?;
+        let output_modules_dir = output_dir.join("modules");
+        let output_scripts_dir = output_dir.join("scripts");
+        std::fs::create_dir_all(&output_modules_dir)?;
+        std::fs::create_dir_all(&output_scripts_dir)?;
 
         let dialect = &*ctx.dialect;
         let sender = Some(ctx.manifest.package.account_address.clone());
@@ -72,13 +72,13 @@ impl Cmd for Prove {
             dialect,
             &sender,
             &ctx.path_for(&ctx.manifest.layout.modules_dir),
-            &artifacts_dir.join("modules"),
+            &output_modules_dir,
         )?;
         prepare_sources(
             dialect,
             &sender,
             &ctx.path_for(&ctx.manifest.layout.scripts_dir),
-            &artifacts_dir.join("scripts"),
+            &output_scripts_dir,
         )?;
 
         let options = Options {
@@ -88,7 +88,7 @@ impl Cmd for Prove {
                 ..Default::default()
             },
             move_deps,
-            move_sources: vec![artifacts_dir.to_string_lossy().to_string()],
+            move_sources: vec![output_dir.to_string_lossy().to_string()],
             account_address: ctx.manifest.package.account_address.clone(),
             ..Default::default()
         };

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -68,8 +68,18 @@ impl Cmd for Prove {
 
         let dialect = &*ctx.dialect;
         let sender = Some(ctx.manifest.package.account_address.clone());
-        prepare_sources(dialect, &sender, &ctx.path_for(&ctx.manifest.layout.modules_dir), &artifacts_dir.join("modules"))?;
-        prepare_sources(dialect, &sender, &ctx.path_for(&ctx.manifest.layout.scripts_dir), &artifacts_dir.join("scripts"))?;
+        prepare_sources(
+            dialect,
+            &sender,
+            &ctx.path_for(&ctx.manifest.layout.modules_dir),
+            &artifacts_dir.join("modules"),
+        )?;
+        prepare_sources(
+            dialect,
+            &sender,
+            &ctx.path_for(&ctx.manifest.layout.scripts_dir),
+            &artifacts_dir.join("scripts"),
+        )?;
 
         let options = Options {
             backend: boogie_backend_v2::options::BoogieOptions {
@@ -104,7 +114,9 @@ fn prepare_sources(
         parser::normalize_source_text(dialect, (&content, &mut mut_content), &sender);
         let content = mut_content.freeze();
 
-        let relative_path = file_path.strip_prefix(&dir).expect("File path does not contain parent dir");
+        let relative_path = file_path
+            .strip_prefix(&dir)
+            .expect("File path does not contain parent dir");
         let output_path = output_dir.join(relative_path);
         std::fs::write(&output_path, content)?;
     }
@@ -121,7 +133,10 @@ fn is_z3_available(z3_exe: &str) -> bool {
 }
 
 /// Checks if executable is available in path by running it.
-fn is_executable_available<S: AsRef<OsStr>, I: IntoIterator<Item=S>>(executable: &str, args: I) -> bool {
+fn is_executable_available<S: AsRef<OsStr>, I: IntoIterator<Item = S>>(
+    executable: &str,
+    args: I,
+) -> bool {
     let status = std::process::Command::new(executable)
         .args(args)
         .stdout(Stdio::null())

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -1,0 +1,67 @@
+use move_prover::{cli::Options, run_move_prover_errors_to_stderr};
+use structopt::StructOpt;
+use anyhow::{ensure, Result};
+use crate::context::Context;
+
+use super::Cmd;
+
+#[cfg(target_family = "unix")]
+const BOOGIE_EXE: &str = "boogie";
+
+#[cfg(target_family = "windows")]
+const BOOGIE_EXE: &str = "boogie.exe";
+
+/// Run move-prover on project files.
+/// Prints output to stderr.
+#[derive(Debug, StructOpt)]
+pub struct Prove {
+    /// Override path to boogie executable.
+    #[structopt(long)]
+    boogie_exe: Option<String>,
+}
+
+impl Cmd for Prove {
+    fn apply(self, ctx: Context) -> Result<()>
+    where
+        Self: std::marker::Sized,
+    {
+        let boogie_exe = self.boogie_exe.unwrap_or(BOOGIE_EXE.to_string());
+        anyhow::ensure!(is_boogie_available(&boogie_exe), "boogie executable not found in PATH. Please install it from https://github.com/boogie-org/boogie");
+
+        let dirs = ctx.paths_for(&[
+            &ctx.manifest.layout.script_dir,
+            &ctx.manifest.layout.module_dir,
+        ]);
+
+        let mut index = ctx.build_index()?;
+        let move_deps = index
+            .make_dependency_set(&dirs)?
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        let move_sources = dirs
+            .into_iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        let options = Options {
+            backend: boogie_backend_v2::options::BoogieOptions {
+                boogie_exe,
+                ..Default::default()
+            },
+            move_deps,
+            move_sources,
+            ..Default::default()
+        };
+        run_move_prover_errors_to_stderr(options)
+    }
+}
+
+/// Checks if `boogie` executable is available in path by running it with `/help` flag.
+fn is_boogie_available(boogie_exe: &str) -> bool {
+    let status = std::process::Command::new(boogie_exe).arg("/help").status();
+    match status {
+        Ok(status) => status.success(),
+        Err(_) => false,
+    }
+}

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -64,12 +64,14 @@ impl Cmd for Prove {
         let options = Options {
             backend: boogie_backend_v2::options::BoogieOptions {
                 boogie_exe,
+                z3_exe: "z3".into(),
                 ..Default::default()
             },
             move_deps,
             move_sources: vec![artifacts_dir.to_string_lossy().to_string()],
             ..Default::default()
         };
+        options.setup_logging();
         run_move_prover_errors_to_stderr(options)
     }
 }

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -29,8 +29,8 @@ impl Cmd for Prove {
         ensure!(is_boogie_available(&boogie_exe), "boogie executable not found in PATH. Please install it from https://github.com/boogie-org/boogie");
 
         let dirs = ctx.paths_for(&[
-            &ctx.manifest.layout.script_dir,
-            &ctx.manifest.layout.module_dir,
+            &ctx.manifest.layout.scripts_dir,
+            &ctx.manifest.layout.modules_dir,
         ]);
 
         let mut index = ctx.build_index()?;

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -25,8 +25,8 @@ impl Cmd for Prove {
     where
         Self: std::marker::Sized,
     {
-        let boogie_exe = self.boogie_exe.unwrap_or(BOOGIE_EXE.to_string());
-        anyhow::ensure!(is_boogie_available(&boogie_exe), "boogie executable not found in PATH. Please install it from https://github.com/boogie-org/boogie");
+        let boogie_exe = self.boogie_exe.unwrap_or_else(|| BOOGIE_EXE.to_string());
+        ensure!(is_boogie_available(&boogie_exe), "boogie executable not found in PATH. Please install it from https://github.com/boogie-org/boogie");
 
         let dirs = ctx.paths_for(&[
             &ctx.manifest.layout.script_dir,

--- a/dove/src/cmd/prover.rs
+++ b/dove/src/cmd/prover.rs
@@ -69,6 +69,7 @@ impl Cmd for Prove {
             },
             move_deps,
             move_sources: vec![artifacts_dir.to_string_lossy().to_string()],
+            account_address: ctx.manifest.package.account_address.clone(),
             ..Default::default()
         };
         options.setup_logging();

--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -88,6 +88,10 @@ fn bundles_output() -> String {
     "artifacts/bundles".to_owned()
 }
 
+fn move_prover_output() -> String {
+    "artifacts/move_prover".to_owned()
+}
+
 fn deps() -> String {
     "artifacts/.external".to_owned()
 }
@@ -135,6 +139,10 @@ pub struct Layout {
     #[serde(default = "transactions_output")]
     pub transactions_output: String,
 
+    /// Directory with move-prover intermediate artifacts.
+    #[serde(default = "move_prover_output")]
+    pub move_prover_output: String,
+
     /// Directory with external dependencies.
     #[serde(default = "deps")]
     pub deps: String,
@@ -159,6 +167,7 @@ impl Layout {
             bundles_output: ctx.str_path_for(&self.bundles_output)?,
             scripts_output: ctx.str_path_for(&self.scripts_output)?,
             transactions_output: ctx.str_path_for(&self.transactions_output)?,
+            move_prover_output: ctx.str_path_for(&self.move_prover_output)?,
             deps: ctx.str_path_for(&self.deps)?,
             artifacts: ctx.str_path_for(&self.artifacts)?,
             index: ctx.str_path_for(&self.index)?,
@@ -176,6 +185,7 @@ impl Default for Layout {
             bundles_output: bundles_output(),
             scripts_output: scripts_output(),
             transactions_output: transactions_output(),
+            move_prover_output: move_prover_output(),
             deps: deps(),
             artifacts: artifacts(),
             index: index(),

--- a/lang/src/compiler/parser.rs
+++ b/lang/src/compiler/parser.rs
@@ -159,7 +159,7 @@ pub fn parse_file(
     }
 }
 
-fn normalize_source_text<'a, 'b>(
+pub fn normalize_source_text<'a, 'b>(
     dialect: &dyn Dialect,
     (source_text, mut_str): (&'a str, &mut MutString<'a, 'b>),
     sender: &'b Option<String>,


### PR DESCRIPTION
Added `dove prove` subcommand that runs `move-prover` on project sources and dependencies.

This functionality is hidden behind `prover` feature-gate until `move-prover` will be fixed.