### PR TITLE
[PONC-150] Better resource output for `dove run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "num-format",
+ "resource-viewer",
  "resources",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap 2.33.3",
+ "diem-types",
  "enum-iterator",
  "git-hash",
  "lang",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -25,4 +25,5 @@ move-vm-types = { git = "https://github.com/pontem-network/diem.git", branch = "
 move-ir-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 vm = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-vm-runtime = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1", features = ["debug_module"] }
+resource-viewer = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 bcs = "0.1.2"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -19,6 +19,7 @@ resources = { path = "../resources" }
 lang = { path = "../lang" }
 git-hash = { path = "../common/git-hash" }
 
+diem-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-lang = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-core-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }
 move-vm-types = { git = "https://github.com/pontem-network/diem.git", branch = "release-1.2.0-v1" }

--- a/executor/src/explain.rs
+++ b/executor/src/explain.rs
@@ -88,6 +88,8 @@ pub enum ChangeType {
     Added,
     /// Resource was modified.
     Changed,
+    /// Resource was removed.
+    Deleted,
 }
 
 impl std::fmt::Display for ChangeType {
@@ -311,8 +313,8 @@ pub fn explain_effects(
                     if Value::simple_deserialize(&value, &layout).is_some() {
                         let state_string =
                             match state.get_resource_bytes(*addr, struct_tag.clone()) {
-                                Some(_) => ChangeType::Added,
-                                None => ChangeType::Changed,
+                                Some(_) => ChangeType::Changed,
+                                None => ChangeType::Added,
                             };
 
                         (
@@ -330,7 +332,7 @@ pub fn explain_effects(
                     }
                 }
                 None => (
-                    ChangeType::Added,
+                    ChangeType::Deleted,
                     ResourceChange(formatted_struct_tag, None),
                 ),
             });

--- a/executor/src/explain.rs
+++ b/executor/src/explain.rs
@@ -124,11 +124,11 @@ pub struct ExplainedTransactionEffects {
 }
 
 impl ExplainedTransactionEffects {
-    pub fn events(&self) -> &Vec<Event> {
+    pub fn events(&self) -> &[Event] {
         &self.events
     }
 
-    pub fn resources(&self) -> &Vec<AddressResourceChanges> {
+    pub fn resources(&self) -> &[AddressResourceChanges] {
         &self.resources
     }
 

--- a/executor/src/format.rs
+++ b/executor/src/format.rs
@@ -1,8 +1,7 @@
 use std::fmt::Write;
 
 use crate::explain::{
-    StepExecutionResult, AddressResourceChanges, ExplainedTransactionEffects,
-    StepResultInfo,
+    StepExecutionResult, AddressResourceChanges, ExplainedTransactionEffects, StepResultInfo,
 };
 
 fn indent(num: usize) -> String {

--- a/executor/src/format.rs
+++ b/executor/src/format.rs
@@ -17,15 +17,15 @@ fn format_error(out: &mut String, error: String) {
 fn format_effects(out: &mut String, effects: ExplainedTransactionEffects) {
     for changes in effects.resources() {
         let AddressResourceChanges { address, changes } = changes;
-        write!(out, "{}", textwrap::indent(address, &indent(1))).unwrap();
+        write!(out, "{}", textwrap::indent(address, &indent(0))).unwrap();
         for change in changes {
-            write!(out, "{}", textwrap::indent(&change.to_string(), &indent(2))).unwrap();
+            write!(out, "{}", textwrap::indent(&change.to_string(), &indent(1))).unwrap();
         }
     }
     if !effects.events().is_empty() {
-        write!(out, "{}", textwrap::indent("Events:", &indent(2))).unwrap();
+        write!(out, "{}", textwrap::indent("Events:", &indent(1))).unwrap();
         for event_change in effects.events() {
-            write!(out, "{}", textwrap::indent(&event_change, &indent(3))).unwrap();
+            write!(out, "{}", textwrap::indent(&event_change, &indent(2))).unwrap();
         }
     }
 }

--- a/executor/src/format.rs
+++ b/executor/src/format.rs
@@ -31,27 +31,14 @@ fn format_effects(out: &mut String, effects: ExplainedTransactionEffects) {
     for changes in effects.resources() {
         let AddressResourceChanges { address, changes } = changes;
         write!(out, "{}", textwrap::indent(address, &indent(1))).unwrap();
-        for (operation, change) in changes {
-            write!(
-                out,
-                "{}",
-                textwrap::indent(
-                    &format!("{} {}", operation, formatted_resource_change(change)),
-                    &indent(2)
-                )
-            )
-            .unwrap();
+        for change in changes {
+            write!(out, "{}", textwrap::indent(&change.to_string(), &indent(2))).unwrap();
         }
     }
     if !effects.events().is_empty() {
         write!(out, "{}", textwrap::indent("Events:", &indent(2))).unwrap();
         for event_change in effects.events() {
-            write!(
-                out,
-                "{}",
-                textwrap::indent(&formatted_resource_change(event_change), &indent(3))
-            )
-            .unwrap();
+            write!(out, "{}", textwrap::indent(&event_change, &indent(3))).unwrap();
         }
     }
 }

--- a/executor/src/format.rs
+++ b/executor/src/format.rs
@@ -5,14 +5,9 @@ use crate::explain::{
     StepResultInfo,
 };
 
-const STEP_INDENT: &str = "    ";
-
 fn indent(num: usize) -> String {
-    let mut indent = String::new();
-    for _ in 0..num {
-        indent += STEP_INDENT;
-    }
-    indent
+    const STEP_INDENT: &str = "    ";
+    std::iter::repeat(STEP_INDENT).take(num).collect()
 }
 
 fn format_error(out: &mut String, error: String) {

--- a/executor/src/format.rs
+++ b/executor/src/format.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::explain::{
-    StepExecutionResult, AddressResourceChanges, ResourceChange, ExplainedTransactionEffects,
+    StepExecutionResult, AddressResourceChanges, ExplainedTransactionEffects,
     StepResultInfo,
 };
 
@@ -13,14 +13,6 @@ fn indent(num: usize) -> String {
         indent += STEP_INDENT;
     }
     indent
-}
-
-fn formatted_resource_change(change: &ResourceChange) -> String {
-    let ResourceChange(ty, val) = change;
-    match val {
-        Some(val) => format!("{} =\n    {}", ty, val),
-        None => ty.to_string(),
-    }
 }
 
 fn format_error(out: &mut String, error: String) {

--- a/executor/tests/test_executor.rs
+++ b/executor/tests/test_executor.rs
@@ -1,4 +1,4 @@
-use move_executor::explain::{ChangeType, AddressResourceChanges, ResourceChange, PipelineExecutionResult};
+use move_executor::explain::{AddressResourceChanges, ResourceChange, PipelineExecutionResult};
 use lang::compiler::file::MoveFile;
 use resources::{assets_dir, stdlib_path, modules_path};
 use lang::compiler::error::CompilerError;
@@ -114,10 +114,7 @@ script {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1111111111111111",
-            vec![(
-                ChangeType::Added,
-                ResourceChange("0x2::Record::T".to_string(), Some("[U8(10)]".to_string()))
-            )],
+            vec![ResourceChange::Added("".to_string())],
         )
     );
 }
@@ -160,10 +157,7 @@ fn missing_write_set_for_move_to_sender() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1",
-            vec![(
-                ChangeType::Added,
-                ResourceChange("0x1::M::T".to_string(), Some("[U8(10)]".to_string()))
-            )],
+            vec![ResourceChange::Added("".to_string())],
         )
     );
 }
@@ -204,13 +198,7 @@ fn test_run_with_non_default_dfinance_dialect() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0xDE5F86CE8AD7944F272D693CB4625A955B610150",
-            vec![(
-                ChangeType::Added,
-                ResourceChange(
-                    "0xDE5F86CE8AD7944F272D693CB4625A955B610150::M::T".to_string(),
-                    Some("[U8(10)]".to_string())
-                )
-            )],
+            vec![ResourceChange::Added("".to_string())],
         )
     );
 }
@@ -254,10 +242,7 @@ fn test_pass_arguments_to_script() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1",
-            vec![(
-                ChangeType::Added,
-                ResourceChange("0x1::Module::T".to_string(), Some("[true]".to_string()))
-            )],
+            vec![ResourceChange::Added("".to_string())],
         )
     );
 }
@@ -401,10 +386,7 @@ fn test_execute_script_with_custom_signer() {
     assert_eq!(effects.resources()[0].address, "0x2");
     assert_eq!(
         effects.resources()[0].changes,
-        vec![(
-            ChangeType::Added,
-            ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
-        )]
+        vec![ResourceChange::Added("".to_string())]
     );
 }
 
@@ -441,20 +423,14 @@ fn test_multiple_signers() {
     assert_eq!(account1_change.address, "0x1");
     assert_eq!(
         account1_change.changes,
-        vec![(
-            ChangeType::Added,
-            ResourceChange("0x2::Record::T".to_string(), Some("[U8(10)]".to_string()))
-        )]
+        vec![ResourceChange::Added("".to_string())]
     );
 
     let account2_change = &effects.resources()[1];
     assert_eq!(account2_change.address, "0x2");
     assert_eq!(
         account2_change.changes,
-        vec![(
-            ChangeType::Added,
-            ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
-        )]
+        vec![ResourceChange::Added("".to_string())]
     );
 }
 
@@ -504,10 +480,7 @@ script {
     assert_eq!(account1_change.address, "0x2");
     assert_eq!(
         account1_change.changes,
-        vec![(
-            ChangeType::Added,
-            ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
-        )]
+        vec![ResourceChange::Added("".to_string())]
     );
 }
 
@@ -662,10 +635,7 @@ script {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x3",
-            vec![(
-                ChangeType::Changed,
-                ResourceChange("0x2::Record::T".to_string(), Some("[U8(11)]".to_string()))
-            )],
+            vec![ResourceChange::Added("".to_string())],
         )
     );
 }
@@ -926,8 +896,8 @@ script {
     .unwrap()
     .effects();
     assert_eq!(
-        effects.resources()[0].changes[0].1,
-        ResourceChange("0x2::Record::T".to_string(), Some("[U8(11)]".to_string()))
+        effects.resources()[0].changes[0],
+        ResourceChange::Added("".to_string())
     );
 }
 

--- a/executor/tests/test_executor.rs
+++ b/executor/tests/test_executor.rs
@@ -1,4 +1,4 @@
-use move_executor::explain::{AddressResourceChanges, ResourceChange, PipelineExecutionResult};
+use move_executor::explain::{ChangeType, AddressResourceChanges, ResourceChange, PipelineExecutionResult};
 use lang::compiler::file::MoveFile;
 use resources::{assets_dir, stdlib_path, modules_path};
 use lang::compiler::error::CompilerError;
@@ -115,7 +115,7 @@ script {
         AddressResourceChanges::new(
             "0x1111111111111111",
             vec![(
-                "Added".to_string(),
+                ChangeType::Added,
                 ResourceChange("0x2::Record::T".to_string(), Some("[U8(10)]".to_string()))
             )],
         )
@@ -161,7 +161,7 @@ fn missing_write_set_for_move_to_sender() {
         AddressResourceChanges::new(
             "0x1",
             vec![(
-                "Added".to_string(),
+                ChangeType::Added,
                 ResourceChange("0x1::M::T".to_string(), Some("[U8(10)]".to_string()))
             )],
         )
@@ -205,7 +205,7 @@ fn test_run_with_non_default_dfinance_dialect() {
         AddressResourceChanges::new(
             "0xDE5F86CE8AD7944F272D693CB4625A955B610150",
             vec![(
-                "Added".to_string(),
+                ChangeType::Added,
                 ResourceChange(
                     "0xDE5F86CE8AD7944F272D693CB4625A955B610150::M::T".to_string(),
                     Some("[U8(10)]".to_string())
@@ -255,7 +255,7 @@ fn test_pass_arguments_to_script() {
         AddressResourceChanges::new(
             "0x1",
             vec![(
-                "Added".to_string(),
+                ChangeType::Added,
                 ResourceChange("0x1::Module::T".to_string(), Some("[true]".to_string()))
             )],
         )
@@ -402,7 +402,7 @@ fn test_execute_script_with_custom_signer() {
     assert_eq!(
         effects.resources()[0].changes,
         vec![(
-            "Added".to_string(),
+            ChangeType::Added,
             ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
         )]
     );
@@ -442,7 +442,7 @@ fn test_multiple_signers() {
     assert_eq!(
         account1_change.changes,
         vec![(
-            "Added".to_string(),
+            ChangeType::Added,
             ResourceChange("0x2::Record::T".to_string(), Some("[U8(10)]".to_string()))
         )]
     );
@@ -452,7 +452,7 @@ fn test_multiple_signers() {
     assert_eq!(
         account2_change.changes,
         vec![(
-            "Added".to_string(),
+            ChangeType::Added,
             ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
         )]
     );
@@ -505,7 +505,7 @@ script {
     assert_eq!(
         account1_change.changes,
         vec![(
-            "Added".to_string(),
+            ChangeType::Added,
             ResourceChange("0x2::Record::T".to_string(), Some("[U8(20)]".to_string()))
         )]
     );
@@ -663,7 +663,7 @@ script {
         AddressResourceChanges::new(
             "0x3",
             vec![(
-                "Changed".to_string(),
+                ChangeType::Changed,
                 ResourceChange("0x2::Record::T".to_string(), Some("[U8(11)]".to_string()))
             )],
         )

--- a/executor/tests/test_executor.rs
+++ b/executor/tests/test_executor.rs
@@ -114,7 +114,9 @@ script {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1111111111111111",
-            vec![ResourceChange::Added("".to_string())],
+            vec![ResourceChange::Added(
+                "store key 0x2::Record::T {\n    age: 10u8\n}\n".to_string()
+            )],
         )
     );
 }
@@ -157,7 +159,9 @@ fn missing_write_set_for_move_to_sender() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1",
-            vec![ResourceChange::Added("".to_string())],
+            vec![ResourceChange::Added(
+                "store key 0x1::M::T {\n    value: 10u8\n}\n".to_string()
+            )],
         )
     );
 }
@@ -198,7 +202,7 @@ fn test_run_with_non_default_dfinance_dialect() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0xDE5F86CE8AD7944F272D693CB4625A955B610150",
-            vec![ResourceChange::Added("".to_string())],
+            vec![ResourceChange::Added("store key 0xde5f86ce8ad7944f272d693cb4625a955b610150::M::T {\n    value: 10u8\n}\n".to_string())],
         )
     );
 }
@@ -242,7 +246,9 @@ fn test_pass_arguments_to_script() {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x1",
-            vec![ResourceChange::Added("".to_string())],
+            vec![ResourceChange::Added(
+                "store key 0x1::Module::T {\n    value: true\n}\n".to_string()
+            )],
         )
     );
 }
@@ -386,7 +392,9 @@ fn test_execute_script_with_custom_signer() {
     assert_eq!(effects.resources()[0].address, "0x2");
     assert_eq!(
         effects.resources()[0].changes,
-        vec![ResourceChange::Added("".to_string())]
+        vec![ResourceChange::Added(
+            "store key 0x2::Record::T {\n    age: 20u8\n}\n".to_string()
+        )]
     );
 }
 
@@ -423,14 +431,18 @@ fn test_multiple_signers() {
     assert_eq!(account1_change.address, "0x1");
     assert_eq!(
         account1_change.changes,
-        vec![ResourceChange::Added("".to_string())]
+        vec![ResourceChange::Added(
+            "store key 0x2::Record::T {\n    age: 10u8\n}\n".to_string()
+        )]
     );
 
     let account2_change = &effects.resources()[1];
     assert_eq!(account2_change.address, "0x2");
     assert_eq!(
         account2_change.changes,
-        vec![ResourceChange::Added("".to_string())]
+        vec![ResourceChange::Added(
+            "store key 0x2::Record::T {\n    age: 20u8\n}\n".to_string()
+        )]
     );
 }
 
@@ -480,7 +492,9 @@ script {
     assert_eq!(account1_change.address, "0x2");
     assert_eq!(
         account1_change.changes,
-        vec![ResourceChange::Added("".to_string())]
+        vec![ResourceChange::Added(
+            "store key 0x2::Record::T {\n    age: 20u8\n}\n".to_string()
+        )]
     );
 }
 
@@ -635,7 +649,9 @@ script {
         effects.resources()[0],
         AddressResourceChanges::new(
             "0x3",
-            vec![ResourceChange::Added("".to_string())],
+            vec![ResourceChange::Changed(
+                "store key 0x2::Record::T {\n    age: 11u8\n}\n".to_string()
+            )],
         )
     );
 }
@@ -897,7 +913,7 @@ script {
     .effects();
     assert_eq!(
         effects.resources()[0].changes[0],
-        ResourceChange::Added("".to_string())
+        ResourceChange::Changed("store key 0x2::Record::T {\n    age: 11u8\n}\n".to_string())
     );
 }
 


### PR DESCRIPTION
Now `dove run` uses `diem/resource-viewer` to pretty-print values. New output format is not ideal, but is better than the current one.

Before:
```
main ...... ok
[gas: 102, writeset bytes: 5]
    0x1
        Added 0x1::Test::Value =
            [[U8(10)], [[U8(10)], [U8(20)], [U8(30)]]]
        Events:
            U64 =
                U64(56)
            0x1::Test::MyEvent =
                [U64(25), [10, 20, 30]]
```

After:
```
main ...... ok
[gas: 102, writeset bytes: 5]
0x1
    Added: drop key 0x1::Test::Value {
        inner: drop store 0x1::Test::Inner {
            value: 10u8
        }
        structs: [
            drop store 0x1::Test::Inner {
                value: 10u8
            },
            drop store 0x1::Test::Inner {
                value: 20u8
            },
            drop store 0x1::Test::Inner {
                value: 30u8
            },
        ]
    }
    Events:
        56
        0x1::Test::MyEvent {
            value: 25
            values: 0a141e
        }
```