### PR TITLE
Fix clippy lint branches_sharing_code

### DIFF
--- a/dove/src/cmd/tx.rs
+++ b/dove/src/cmd/tx.rs
@@ -114,6 +114,7 @@ impl<'a> TransactionBuilder<'a> {
         })
     }
 
+    #[allow(clippy::branches_sharing_code)]
     pub fn parse_call(call: &str) -> Result<(String, Vec<TypeTag>, Vec<String>), Error> {
         let mut mut_string = MutString::new(call);
         replace_ss58_addresses(call, &mut mut_string, &mut Default::default());


### PR DESCRIPTION
Clippy incorrectly applies lint branches_sharing_code on if statement
inside parse_call function. It does not takes into consideration side
effects produced by the code.

CI failure affects #68 