### PR TITLE
[PONC-153] Use actual deps when building Index

### DIFF
--- a/dove/src/index/resolver/git.rs
+++ b/dove/src/index/resolver/git.rs
@@ -195,6 +195,9 @@ pub fn make_local_name(git: &Git) -> String {
     if let Some(path) = &git.path {
         digest.update(path.as_bytes());
     }
+    if let Some(tag) = &git.tag {
+        digest.update(tag.as_bytes());
+    }
     let mut output = [0; 32];
     digest.finalize(&mut output);
     format!("{}_{}", PREFIX, hex::encode(&output))

--- a/dove/src/index/store.rs
+++ b/dove/src/index/store.rs
@@ -40,8 +40,6 @@ pub enum SourceType {
 pub struct Module {
     /// Module address and name.
     pub name: Rc<ModuleId>,
-    /// Dependency name.
-    pub dep_name: Rc<str>,
     /// Path to the dependencies.
     pub path: Rc<str>,
     /// Dependency type.
@@ -57,8 +55,6 @@ impl<'a> Index<'a> {
         if index_path.exists() {
             let index = toml::from_str::<Modules>(&fs::read_to_string(index_path)?)?;
 
-            let dep_names = index.modules.iter().map(|m| m.dep_name.clone()).collect();
-
             let modules = index.modules.into_iter().map(|m| (m.name.clone(), m)).fold(
                 HashMap::new(),
                 |mut acc, (name, m)| {
@@ -68,15 +64,10 @@ impl<'a> Index<'a> {
                 },
             );
 
-            Ok(Index {
-                modules,
-                dep_names,
-                ctx,
-            })
+            Ok(Index { modules, ctx })
         } else {
             Ok(Index {
                 modules: Default::default(),
-                dep_names: Default::default(),
                 ctx,
             })
         }

--- a/dove/src/index/store.rs
+++ b/dove/src/index/store.rs
@@ -7,8 +7,10 @@ use std::io::Write;
 use serde::{Serialize, Deserialize};
 use crate::index::Index;
 use std::rc::Rc;
+use std::path::Path;
 use std::collections::{HashMap, HashSet};
 use move_core_types::language_storage::ModuleId;
+use super::resolver::{git, chain};
 
 /// Modules holder.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -33,6 +35,20 @@ pub enum SourceType {
     Git,
     /// Blockchain dependencies.
     Chain,
+}
+
+impl SourceType {
+    /// Determines SourceType depending on path (namely, prefix of the filename).
+    pub fn try_from_path(path: &Path) -> Option<Self> {
+        let file_name = path.file_name()?.to_str()?;
+        if file_name.starts_with(git::PREFIX) {
+            Some(Self::Git)
+        } else if file_name.starts_with(chain::PREFIX) {
+            Some(Self::Chain)
+        } else {
+            Some(Self::Local)
+        }
+    }
 }
 
 /// Module model.


### PR DESCRIPTION
Fixes weird issue with unrelated errors reported on `dove build`.
To reproduce:
1. Create a fresh Dove project
1. Change move-stdlib version in deps to smth like 0.1.0
1. Run dove build --tree : you’ll see an error due to syntax incompatibility
1. Change move-stdlib version back to current (like 0.1.2)
1. Run dove build --tree : error is still there, though it shouldn’t

See individual commits for details.