### PR TITLE
specific version of indexmap (1.6.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "git2",
  "hex",
  "http",
+ "indexmap",
  "itertools 0.9.0",
  "lang",
  "lazy_static",
@@ -2140,12 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "headers"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,12 +2457,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.11.2",
+ "hashbrown 0.9.1",
  "serde",
 ]
 

--- a/dove/Cargo.toml
+++ b/dove/Cargo.toml
@@ -35,6 +35,7 @@ git2 = "0.13"
 bcs = "0.1.2"
 dunce = "1.0.1"
 atty = "0.2"
+indexmap = { version = "=1.6.2", default-features = false, features = ["std"] }
 
 lang = { path = "../lang" }
 decompiler = { path = "../lang/decompiler" }


### PR DESCRIPTION
I chose a specific version of indexmap (1.6.2) because of problems with cyclic dependency (1.7.0).

Version 1.6.2 used in current diem release.