### PR TITLE
Nix build/environment support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tests/_*
 /*.move
 execute.sh
 test.sh
+
+# Direnv cache
+.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,138 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1625773658,
+        "narHash": "sha256-SO/THVyPWfA5ZKAz8GGmLAdkBvNS4OwvHAu6aTOteTE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "164b7a893a2816e8def495968a1a7ce149b49489",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1623927034,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "naersk_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1623927034,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1625533413,
+        "narHash": "sha256-D4Dp2qDmY3Y9/Mqxsha/18F0RsH3hPiHafG4bvTz2V4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "036dc0c709650e0c833822307af801f576d67273",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1625704207,
+        "narHash": "sha256-y7pnPYrc9NKhWMDtM1eucGYQoDd/H33/6DL1sjGosr0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7b4ff2184e4cab274ecb2b2eb49d20ef2142ddf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "naersk": "naersk_2",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1625696015,
+        "narHash": "sha256-IDfYLXBY4m9+XfbnH2i/rtzKS1kRcYpHRZSrV6ZCMUo=",
+        "owner": "rust-analyzer",
+        "repo": "rust-analyzer",
+        "rev": "85f0f9eb1bb7eedf11a3947508fccba66f22d108",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-analyzer",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    fenix.url = "github:nix-community/fenix";
+    naersk = {
+      url = "github:nmattia/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk, fenix }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        fenixArch = fenix.packages.${system};
+        rustTargets = fenixArch.targets;
+        llvmPackages = pkgs.llvmPackages_12;
+
+        rustToolchain = fenixArch.latest;
+        rustToolchainWasm = rustTargets.wasm32-unknown-unknown.latest;
+
+        naersk-lib = naersk.lib.${system}.override {
+          cargo = rustToolchain.toolchain;
+          rustc = rustToolchain.toolchain;
+        };
+
+      in {
+
+        defaultPackage = naersk-lib.buildPackage (with pkgs; {
+          src = ./.;
+          #src = ./dove;
+	  targets = [ "dove" ];
+	  buildInputs = [ pkg-config openssl ];
+          PROTOC = "${protobuf}/bin/protoc";
+          PROTOC_INCLUDE="${protobuf}/include";
+          LLVM_CONFIG_PATH="${llvmPackages.bintools}/bin/llvm-config";
+          LIBCLANG_PATH="${llvmPackages_11.clang-unwrapped.lib}/lib";
+          RUST_SRC_PATH = "${rustToolchain.rust-src}/lib/rustlib/src/rust/library/";
+
+        #   SKIP_WASM_BUILD = 1;
+        });
+
+        defaultApp = utils.mkApp {
+            drv = self.defaultPackage."${system}";
+        };
+
+        devShell =
+        with pkgs; mkShell {
+          buildInputs = [
+            protobuf openssl pre-commit pkg-config
+            llvmPackages.libclang.out
+            cargo-binutils
+
+            (fenixArch.combine [
+              fenixArch.latest.toolchain
+              rustTargets.wasm32-unknown-unknown.stable.toolchain
+              # rustToolchainWasm.toolchain
+            ])
+
+          ];
+
+#          SKIP_WASM_BUILD = 1;
+          PROTOC = "${protobuf}/bin/protoc";
+          PROTOC_INCLUDE="${protobuf}/include";
+          LLVM_CONFIG_PATH="${llvmPackages.bintools}/bin/llvm-config";
+          LIBCLANG_PATH="${llvmPackages_11.clang-unwrapped.lib}/lib";
+          RUST_SRC_PATH = "${rustToolchain.rust-src}/lib/rustlib/src/rust/library/";
+
+        };
+
+      });
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         llvmPackages = pkgs.llvmPackages_12;
 
         rustToolchain = fenixArch.latest;
-        rustToolchainWasm = rustTargets.wasm32-unknown-unknown.latest;
+        rustToolchainWasm = rustTargets.wasm32-unknown-unknown.stable;
 
         naersk-lib = naersk.lib.${system}.override {
           cargo = rustToolchain.toolchain;
@@ -28,43 +28,37 @@
       in {
 
         defaultPackage = naersk-lib.buildPackage (with pkgs; {
+
           src = ./.;
-          #src = ./dove;
-	  targets = [ "dove" ];
-	  buildInputs = [ pkg-config openssl ];
+	        targets = [ "dove" ];
+	        buildInputs = [ pkg-config openssl ];
+
           PROTOC = "${protobuf}/bin/protoc";
           PROTOC_INCLUDE="${protobuf}/include";
           LLVM_CONFIG_PATH="${llvmPackages.bintools}/bin/llvm-config";
-          LIBCLANG_PATH="${llvmPackages_11.clang-unwrapped.lib}/lib";
-          RUST_SRC_PATH = "${rustToolchain.rust-src}/lib/rustlib/src/rust/library/";
+          LIBCLANG_PATH="${llvmPackages.clang-unwrapped.lib}/lib";
 
-        #   SKIP_WASM_BUILD = 1;
         });
 
         defaultApp = utils.mkApp {
             drv = self.defaultPackage."${system}";
         };
 
-        devShell =
-        with pkgs; mkShell {
+        devShell = with pkgs; mkShell {
           buildInputs = [
-            protobuf openssl pre-commit pkg-config
-            llvmPackages.libclang.out
-            cargo-binutils
+            openssl pre-commit pkg-config
 
             (fenixArch.combine [
-              fenixArch.latest.toolchain
-              rustTargets.wasm32-unknown-unknown.stable.toolchain
-              # rustToolchainWasm.toolchain
+              rustToolchain.toolchain
+              rustToolchainWasm.toolchain
             ])
 
           ];
 
-#          SKIP_WASM_BUILD = 1;
           PROTOC = "${protobuf}/bin/protoc";
           PROTOC_INCLUDE="${protobuf}/include";
           LLVM_CONFIG_PATH="${llvmPackages.bintools}/bin/llvm-config";
-          LIBCLANG_PATH="${llvmPackages_11.clang-unwrapped.lib}/lib";
+          LIBCLANG_PATH="${llvmPackages.clang-unwrapped.lib}/lib";
           RUST_SRC_PATH = "${rustToolchain.rust-src}/lib/rustlib/src/rust/library/";
 
         };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
After a lot of failures, several PRs to Nix Rust infra and countless sleepless nights, I present to you... initial Nix derivation and environment!

To test the build: 
```
nix-shell -p git nixFlakes --command 'nix build --experimental-features "nix-command flakes" github:pontem-network/move-tools/nix'
```

Building on x86_64-linux works flawlessly, other OS-s and architectures are to be tested.
There's also a ,envrc file, which provides you with dev environment if you use [direnv](https://direnv.net/)