### PR TITLE
Dove: bug fix: Windows: Error when cloning a git repository

### DIFF
--- a/dove/src/manifest.rs
+++ b/dove/src/manifest.rs
@@ -1,6 +1,6 @@
 use std::{fmt, fs};
 use std::convert::TryFrom;
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR as MS};
 
 use anyhow::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -79,23 +79,23 @@ fn tests_dir() -> String {
 }
 
 fn modules_output() -> String {
-    "artifacts/modules".to_owned()
+    format!("{}{}{}", artifacts(), MS, "modules")
 }
 
 fn scripts_output() -> String {
-    "artifacts/scripts".to_owned()
+    format!("{}{}{}", artifacts(), MS, "scripts")
 }
 
 fn transactions_output() -> String {
-    "artifacts/transactions".to_owned()
+    format!("{}{}{}", artifacts(), MS, "transactions")
 }
 
 fn bundles_output() -> String {
-    "artifacts/bundles".to_owned()
+    format!("{}{}{}", artifacts(), MS, "bundles")
 }
 
 fn move_prover_output() -> String {
-    "artifacts/move_prover".to_owned()
+    format!("{}{}{}", artifacts(), MS, "move_prover")
 }
 
 fn docs_output() -> String {
@@ -103,11 +103,11 @@ fn docs_output() -> String {
 }
 
 fn deps() -> String {
-    "artifacts/.external".to_owned()
+    format!("{}{}{}", artifacts(), MS, ".external")
 }
 
 fn chain_deps() -> String {
-    "artifacts/.external/chain".to_owned()
+    format!("{}{}{}", deps(), MS, "chain")
 }
 
 fn artifacts() -> String {
@@ -115,7 +115,7 @@ fn artifacts() -> String {
 }
 
 fn index() -> String {
-    "artifacts/.Dove.man".to_owned()
+    format!("{}{}{}", artifacts(), MS, ".Dove.man")
 }
 
 fn code_code_address() -> String {

--- a/dove/tests/test_cmd_dove_run.rs
+++ b/dove/tests/test_cmd_dove_run.rs
@@ -58,8 +58,6 @@ fn test_cmd_dove_run_multiple_scripts() {
 }
 
 #[test]
-#[ignore]
-// @todo bug windows
 fn test_cmd_dove_run_dependency_with_git_tag() {
     for v in 1..=2 {
         let project_folder = create_project_for_test_dependency(
@@ -86,8 +84,6 @@ fn test_cmd_dove_run_dependency_with_git_tag() {
 }
 
 #[test]
-#[ignore]
-// @todo bug windows
 fn test_cmd_dove_run_dependency_with_rev() {
     for (value, rev) in &[
         (1, "049200421c880f9f4269d6406c2b1537891b23c7"),
@@ -117,8 +113,6 @@ fn test_cmd_dove_run_dependency_with_rev() {
 }
 
 #[test]
-#[ignore]
-// @todo bug windows
 fn test_cmd_dove_run_dependencies_in_dependencies() {
     let project_folder = create_project_for_test_dependency(
         "project_run_dependencies_in_dependencies",


### PR DESCRIPTION
Package Git2 for Windows:
Failed to clone repository: [https://github.com/pontem-network/move-stdlib]: | path too long: 'C:/Users/RUNNER~1/AppData/Local/Temp/project_run_dependencies_in_dependencies/artifacts/.external/git_f5451f91ccc0b912268c6b086cdaa92971c09c7b3db3c49b3161d2ae00d40ec0'

