### PR TITLE
[v1.5] $ dove build - fix bug + test

### DIFF
--- a/dove/src/tx/cmd.rs
+++ b/dove/src/tx/cmd.rs
@@ -29,8 +29,7 @@ Examples:
     #[structopt(
         help = r#"Script arguments, e.g. 10 20 30"#,
         name = "Script arguments.",
-        long = "args",
-        short = "a"
+        long = "args"
     )]
     args: Option<Vec<String>>,
     #[structopt(
@@ -59,7 +58,9 @@ impl CallDeclarationCmd {
 impl TryFrom<(&AddressDeclarations, CallDeclarationCmd)> for CallDeclaration {
     type Error = Error;
 
-    fn try_from((addr_map, cmd): (&AddressDeclarations, CallDeclarationCmd)) -> Result<Self, Self::Error> {
+    fn try_from(
+        (addr_map, cmd): (&AddressDeclarations, CallDeclarationCmd),
+    ) -> Result<Self, Self::Error> {
         let mut call = parse_call(&addr_map, &cmd.call)?;
         if let Some(args) = cmd.args {
             call.set_args(args);

--- a/dove/tests/test_cmd_dove_build.rs
+++ b/dove/tests/test_cmd_dove_build.rs
@@ -2,7 +2,8 @@ mod helper;
 
 use std::fs;
 use std::io::Read;
-use crate::helper::{delete_project, execute_dove_at, new_demo_project};
+use crate::helper::{delete_project, execute_dove_at, new_demo_project, build, create_new_project};
+use std::collections::HashMap;
 
 /// Build a project without additional parameters
 /// $ dove build
@@ -84,6 +85,17 @@ fn test_cmd_dove_build_error_map() {
 
     execute_dove_at(&["build", "--error-map", "error_map"], &project_path).unwrap();
     assert!(project_path.join("error_map.errmap").exists());
+
+    delete_project(&project_path).unwrap();
+}
+
+#[test]
+fn test_cmd_dove_build_two_times() {
+    let project_name = "project_build_two_times";
+    let project_path = create_new_project(&project_name, HashMap::new()).unwrap();
+
+    build(&project_path).unwrap();
+    build(&project_path).unwrap();
 
     delete_project(&project_path).unwrap();
 }


### PR DESCRIPTION
Fixes an error when reassembling an empty project
    <PROJECT_DIR>/build/<PROJECT_NAME>/bytecode_modules
    <PROJECT_DIR>/build/<PROJECT_NAME>/bytecode_scripts
    <PROJECT_DIR>/build/<PROJECT_NAME>/source_maps
    <PROJECT_DIR>/build/<PROJECT_NAME>/sources